### PR TITLE
wezterm: add font fallback chain for missing fonts

### DIFF
--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -115,8 +115,17 @@ config.set_environment_variables = ok and env_vars or {}
 -- ============================================================================
 -- APPEARANCE
 -- ============================================================================
--- Font configuration
-config.font = wezterm.font { family = 'ZedMono Nerd Font', stretch = 'Expanded' }
+-- Font configuration with fallback chain
+-- WezTerm skips unavailable fonts and uses the next available one
+config.font = wezterm.font_with_fallback {
+  { family = 'ZedMono Nerd Font', stretch = 'Expanded' },
+  'JetBrains Mono',
+  'Fira Code',
+  'Cascadia Code',
+  'Menlo',
+  'Consolas',
+  'Courier New',
+}
 config.font_size = local_settings.font_size
 
 -- Color settings

--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -122,6 +122,7 @@ config.font = wezterm.font_with_fallback {
   'JetBrains Mono',
   'Fira Code',
   'Cascadia Code',
+  'Iosevka',
   'Menlo',
   'Consolas',
   'Courier New',


### PR DESCRIPTION
Use wezterm.font_with_fallback so that if ZedMono Nerd Font isn't
installed, WezTerm automatically falls back to JetBrains Mono,
Fira Code, Cascadia Code, Menlo, Consolas, or Courier New.

https://claude.ai/code/session_012xVGQB5LBHbekbDMzPgSA1